### PR TITLE
WIP: Added build matrix to handle linting of multiple Dockerfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,27 @@ on:
       - 'master'
 
 jobs:
-  linter:
+  matrix:
+    # Generate matrix for linting (essentially locating all Dockerfile directories)
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-dockerfiles.outputs.matrix }}
+    steps:
+    - id: set-dockerfiles
+      run: |
+        PATHS_TO_DOCKERFILE=`./paths_to_dockerfile.sh | jq .`
+        echo "::set-output name=matrix::$PATHS_TO_DOCKERFILE"
+  linter:
+    # Run linter on all located Dockerfiles
+    needs: [matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2 
       - uses: hadolint/hadolint-action@v1.5.0
         with:
-          dockerfile: Dockerfile
+          dockerfile: ${{ matrix.dockerfiles }}
   build:
     needs: [linter]
     # Should consider to use https://github.com/marketplace/actions/build-and-push-docker-images instead, but requires rewrite

--- a/paths_to_dockefile.sh
+++ b/paths_to_dockefile.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+STRING=`find -name Dockerfile`
+PATHS_TO_DOCKERFILE=($STRING)
+echo '{ "dockerfiles" : ['
+for path in ${PATHS_TO_DOCKERFILE[@]};
+do
+    if [[ $path == ${PATHS_TO_DOCKERFILE[-1]} ]];
+    then
+	echo "\"$path\""
+    else
+	echo "\"$path\","
+    fi
+done
+echo "]}"


### PR DESCRIPTION
Here we add a matrix to enable linting of the different Dockerfiles. We have not yet updated the build script, but in the future we should use the same approach to locate the different directories to be prepared for a build. We should consider to use a build matrix as also here as it gives some benefits.